### PR TITLE
add support for sidekiq 8.*

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -4,7 +4,7 @@ PATH
     desiru (0.2.0)
       forwardable (~> 1.3)
       redis (~> 5.0)
-      sidekiq (~> 7.2)
+      sidekiq (>= 7.2, < 9.0)
       singleton (~> 0.1)
 
 GEM

--- a/desiru.gemspec
+++ b/desiru.gemspec
@@ -33,7 +33,7 @@ Gem::Specification.new do |spec|
   # Runtime dependencies
   spec.add_dependency 'forwardable', '~> 1.3'
   spec.add_dependency 'redis', '~> 5.0'
-  spec.add_dependency 'sidekiq', '~> 7.2'
+  spec.add_dependency 'sidekiq', '>= 7.2', '< 9.0'
   spec.add_dependency 'singleton', '~> 0.1'
 
   # Development dependencies moved to Gemfile


### PR DESCRIPTION
Allow those of us on sidekiq 8.* to use Desiru.


Without change, it errors with incompatible dependencies:

```log
❯ bundle add desiru
Fetching gem metadata from https://gems.contribsys.com/..
Fetching gem metadata from https://rubygems.org/........
Resolving dependencies...
Could not find compatible versions

Because sidekiq-throttled >= 2.0.0 depends on sidekiq >= 8.0
  and every version of desiru depends on sidekiq ~> 7.2,
  sidekiq-throttled >= 2.0.0 is incompatible with desiru >= 0.
So, because Gemfile depends on sidekiq-throttled ~> 2.0
  and Gemfile depends on desiru >= 0,
  version solving has failed.
```

With change, we can bundle add

